### PR TITLE
AWS provider deprecation warning fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,9 +43,13 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
 
 resource "aws_s3_bucket" "s3_bucket" {
   bucket = var.domain_name
-  acl    = "private"
   policy = data.aws_iam_policy_document.s3_bucket_policy.json
   tags   = var.tags
+}
+
+resource "aws_s3_bucket_acl" "s3_bucket" {
+  bucket = var.domain_name
+  acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "s3_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -44,11 +44,15 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
 resource "aws_s3_bucket" "s3_bucket" {
   bucket = var.domain_name
   acl    = "private"
-  versioning {
-    enabled = true
-  }
   policy = data.aws_iam_policy_document.s3_bucket_policy.json
   tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "s3_bucket" {
+  bucket = var.domain_name
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_object" "object" {


### PR DESCRIPTION
This fixes the s3 bucket versioning and acl deprecation warnings. this will fix #9.