### PR TITLE
upgrading module for tf 1.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 # .tfvars files
 *.tfvars
 .idea/*
+
+.terraform.*

--- a/error.html
+++ b/error.html
@@ -1,0 +1,9 @@
+<!Doctype html>
+<html>
+<head>
+    <title>Sample Application</title>
+</head>
+<body>
+<h1>ERROR also works !!!</h1>
+</body>
+</html>

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
-provider "aws" {
-  region = "us-east-1"
-  alias  = "aws_cloudfront"
-}
+# provider "aws" {
+#   region = "us-east-1"
+#   alias  = "aws_cloudfront"
+# }
 
 locals {
   default_certs = var.use_default_domain ? ["default"] : []
@@ -12,7 +12,7 @@ locals {
 data "aws_acm_certificate" "acm_cert" {
   count    = var.use_default_domain ? 0 : 1
   domain   = coalesce(var.acm_certificate_domain, "*.${var.hosted_zone}")
-  provider = aws.aws_cloudfront
+  # provider = aws.aws_cloudfront
   //CloudFront uses certificates from US-EAST-1 region only
   statuses = [
     "ISSUED",

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 locals {
   default_certs = var.use_default_domain ? ["default"] : []
   acm_certs     = var.use_default_domain ? [] : ["acm"]
-  domain_name   = var.use_default_domain ? [] : [var.domain_name]
+  domain_name   = [var.domain_name]
 }
 
 data "aws_acm_certificate" "acm_cert" {
@@ -103,7 +103,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 
-  aliases = var.domain_name
+  aliases = local.domain_name
 
   default_cache_behavior {
     allowed_methods = [

--- a/main.tf
+++ b/main.tf
@@ -61,13 +61,13 @@ resource "aws_s3_bucket_object" "object" {
 }
 
 data "aws_route53_zone" "domain_name" {
-  count        = var.use_default_domain or !var.route53_record ? 0 : 1
+  count        = var.use_default_domain || !var.route53_record ? 0 : 1
   name         = var.hosted_zone
   private_zone = false
 }
 
 resource "aws_route53_record" "route53_record" {
-  count = var.use_default_domain or !var.route53_record ? 0 : 1
+  count = var.use_default_domain || !var.route53_record ? 0 : 1
   depends_on = [
     aws_cloudfront_distribution.s3_distribution
   ]

--- a/main.tf
+++ b/main.tf
@@ -61,13 +61,13 @@ resource "aws_s3_bucket_object" "object" {
 }
 
 data "aws_route53_zone" "domain_name" {
-  count        = var.use_default_domain ? 0 : 1
+  count        = var.use_default_domain or !var.route53_record ? 0 : 1
   name         = var.hosted_zone
   private_zone = false
 }
 
 resource "aws_route53_record" "route53_record" {
-  count = var.use_default_domain ? 0 : 1
+  count = var.use_default_domain or !var.route53_record ? 0 : 1
   depends_on = [
     aws_cloudfront_distribution.s3_distribution
   ]

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_versioning" "s3_bucket" {
   }
 }
 
-resource "aws_s3_bucket_object" "object" {
+resource "aws_s3_object" "object" {
   count        = var.upload_sample_file ? 1 : 0
   bucket       = aws_s3_bucket.s3_bucket.bucket
   key          = "index.html"

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 
-  aliases = local.domain_name
+  aliases = var.domain_name
 
   default_cache_behavior {
     allowed_methods = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@ output "s3_domain_name" {
 output "website_address" {
   value = var.domain_name
 }
+
+output "s3_arn" {
+  value = aws_s3_bucket.s3_bucket.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "cloudfront_dist_id" {
 }
 
 output "s3_domain_name" {
-  value = aws_s3_bucket.s3_bucket.website_domain
+  value = aws_s3_bucket_website_configuration.s3_bucket.website_domain
 }
 
 output "website_address" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,3 @@ variable "cloudfront_max_ttl" {
   default     = 31536000
   description = "The maximum TTL for the cloudfront cache"
 }
-
-variable "route53_record" {
-  default = true
-}

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,22 @@ variable "cloudfront_max_ttl" {
   default     = 31536000
   description = "The maximum TTL for the cloudfront cache"
 }
+
+variable "cloudfront_geo_restriction_restriction_type" {
+  default     = "none"
+  description = "The method that you want to use to restrict distribution of your content by country: none, whitelist, or blacklist."
+  validation {
+    error_message = "Can only specify either none, whitelist, blacklist"
+    condition     = can(regex("^(none|whitelist|blacklist)$", var.cloudfront_geo_restriction_restriction_type))
+  }
+
+}
+variable "cloudfront_geo_restriction_locations" {
+  default     = []
+  description = "The ISO 3166-1-alpha-2 codes for which you want CloudFront either to distribute your content (whitelist) or not distribute your content (blacklist)."
+  validation {
+    error_message = "must be a valid ISO 3166-1-alpha-2 code"
+    condition     = length(var.cloudfront_geo_restriction_locations) == 2
+  }
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,5 @@ variable "upload_sample_file" {
 }
 
 variable "route53_record" {
-  default = true
-  type    = boolean
+  default = true  
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,8 @@ variable "upload_sample_file" {
   default     = false
   description = "Upload sample html file to s3 bucket"
 }
+
+variable "route53_record" {
+  default = true
+  type    = boolean
+}


### PR DESCRIPTION
- Upgrading module for tf 1.2.8
- Provider hashicorp/aws is ~> 4.0
- Moving policy attribute from aws_s3_bucket to aws_s3_bucket_policy
- Adding aws_s3_bucket_website_configuration resource
- Adding error.html aws_s3_object as part of example
- Renaming aws_s3_bucket_object to aws_s3_object